### PR TITLE
build: use poetry plugin in charmcraft.yaml

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v31.0.1
     with:
       path-to-charm-directory: ${{ matrix.charm }}
-      cache: false
+      cache: false # TODO remove when charm is added to charmcraftcache 
     
   integration:
     name: Integration tests (microk8s)

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,6 +106,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v31.0.1
     with:
       path-to-charm-directory: ${{ matrix.charm }}
+      cache: false
     
   integration:
     name: Integration tests (microk8s)

--- a/charms/feast-integrator/charmcraft.yaml
+++ b/charms/feast-integrator/charmcraft.yaml
@@ -51,7 +51,7 @@ parts:
     source: .
     after:
       - poetry-deps
-    poetry-export-extra-args: ['--only', 'main,charm-libs']
+    poetry-export-extra-args: ['--only', 'main']
     override-build: |
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/feast-integrator/charmcraft.yaml
+++ b/charms/feast-integrator/charmcraft.yaml
@@ -1,5 +1,6 @@
-# This file configures Charmcraft.
-# See https://juju.is/docs/sdk/charmcraft-config for guidance.
+# Copyright 2025 Canonical Ltd.
+# See LICENSE file for licensing details.
+
 type: charm
 
 platforms:
@@ -8,31 +9,49 @@ platforms:
 # - dispatch (https://github.com/canonical/charmcraft/pull/1898)
 # - manifest.yaml
 #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L259)
+# Files implicitly copied/"staged" by charmcraft without a part:
+# - actions.yaml, config.yaml, metadata.yaml
+#   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L290-L293
+#   https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/services/package.py#L156-L157)
 parts:
-  # "python-deps" part name is arbitrary; use for consistency
-  # (but could become a magic constant in the future, similar to "poetry-deps"
-  # https://github.com/canonical/craft-parts/pull/901)
-  python-deps:
+  # "poetry-deps" part name is a magic constant
+  # https://github.com/canonical/craft-parts/pull/901
+  poetry-deps:
     plugin: nil
+    build-packages:
+      - curl
     override-build: |
       # Use environment variable instead of `--break-system-packages` to avoid failing on older
       # versions of pip that do not recognize `--break-system-packages`
       # `--user` needed (in addition to `--break-system-packages`) for Ubuntu >=24.04
       PIP_BREAK_SYSTEM_PACKAGES=true python3 -m pip install --user --upgrade pip==25.0.1  # renovate: charmcraft-pip-latest
-  # "charm-python" part name is arbitrary; use for consistency
+
+      # Use uv to install poetry so that a newer version of Python can be installed if needed by poetry
+      curl --proto '=https' --tlsv1.2 -LsSf https://github.com/astral-sh/uv/releases/download/0.6.16/uv-installer.sh | sh  # renovate: charmcraft-uv-latest
+      # poetry 2.0.0 requires Python >=3.9
+      if ! "$HOME/.local/bin/uv" python find '>=3.9'
+      then
+        # Use first Python version that is >=3.9 and available in an Ubuntu LTS
+        # (to reduce the number of Python versions we use)
+        "$HOME/.local/bin/uv" python install 3.10.12  # renovate: charmcraft-python-ubuntu-22.04
+      fi
+      "$HOME/.local/bin/uv" tool install --no-python-downloads --python '>=3.9' poetry==2.1.2 --with poetry-plugin-export==1.9.0  # renovate: charmcraft-poetry-latest
+
+      ln -sf "$HOME/.local/bin/poetry" /usr/local/bin/poetry
+  # "charm-poetry" part name is arbitrary; use for consistency
   # Avoid using "charm" part name since that has special meaning to charmcraft
-  charm-python:
-    # By default, the `python` plugin creates/stages these directories:
+  charm-poetry:
+    # By default, the `poetry` plugin creates/stages these directories:
     # - lib, src
-    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_python.py#L79-L81)
+    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L76-L78)
     # - venv
-    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_python.py#L100
+    #   (https://github.com/canonical/charmcraft/blob/9ff19c328e23b50cc06f04e8a5ad4835740badf4/charmcraft/parts/plugins/_poetry.py#L95
     #   https://github.com/canonical/craft-parts/blob/afb0d652eb330b6aaad4f40fbd6e5357d358de47/craft_parts/plugins/base.py#L270)
-    plugin: python
+    plugin: poetry
     source: .
     after:
-      - python-deps
-    python-requirements: [requirements.txt]
+      - poetry-deps
+    poetry-export-extra-args: ['--only', 'main,charm-libs']
     override-build: |
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging

--- a/charms/feast-integrator/charmcraft.yaml
+++ b/charms/feast-integrator/charmcraft.yaml
@@ -52,7 +52,30 @@ parts:
     after:
       - poetry-deps
     poetry-export-extra-args: ['--only', 'main']
+    build-packages:
+      - libffi-dev  # Needed to build Python dependencies with Rust from source
+      - libssl-dev  # Needed to build Python dependencies with Rust from source
+      - pkg-config  # Needed to build Python dependencies with Rust from source
     override-build: |
+      # Workaround for https://github.com/canonical/charmcraft/issues/2068
+      # rustup used to install rustc and cargo, which are needed to build Python dependencies with Rust from source
+      if [[ "$CRAFT_PLATFORM" == ubuntu@20.04:* || "$CRAFT_PLATFORM" == ubuntu@22.04:* ]]
+      then
+        snap install rustup --classic
+      else
+        apt-get install rustup -y
+      fi
+
+      # If Ubuntu version < 24.04, rustup was installed from snap instead of from the Ubuntu
+      # archive—which means the rustup version could be updated at any time. Print rustup version
+      # to build log to make changes to the snap's rustup version easier to track
+      rustup --version
+
+      # rpds-py (Python package) >=0.19.0 requires rustc >=1.76, which is not available in the
+      # Ubuntu 22.04 archive. Install rustc and cargo using rustup instead of the Ubuntu archive
+      rustup set profile minimal
+      rustup default 1.83.0  # renovate: charmcraft-rust-latest
+
       craftctl default
       # Include requirements.txt in *.charm artifact for easier debugging
       cp requirements.txt "$CRAFT_PART_INSTALL/requirements.txt"


### PR DESCRIPTION
* Uses poetry plugin instead of python plugin in charmcraft.yaml
* Adds rust dependencies needed by `cryptography`, See failure [here](https://github.com/canonical/feast-operators/actions/runs/14778560981/job/41492350178)
* Implements same charmcraft.yaml structure of DP charms, [example in etcd](https://github.com/canonical/charmed-etcd-operator/blob/3.5/edge/charmcraft.yaml)
* Disables cache during build with a TODO to re-enable it, once we merge this PR, we'll re-add the charm to `ccc` and remove `cache: false` input in a follow-up PR.

Note that poetry pyproject.toml and lock file is already implemented in #5 but we missed replacing python plugin with poetry plugin.