### PR TITLE
chore: enable charm build with cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -106,7 +106,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v31.0.1
     with:
       path-to-charm-directory: ${{ matrix.charm }}
-      cache: false # TODO remove when charm is added to charmcraftcache 
     
   integration:
     name: Integration tests (microk8s)


### PR DESCRIPTION
Removes `cache: false` from build workflow call since the charm is now added to `charmcraftcache-hub` in https://github.com/canonical/charmcraftcache-hub/pull/434 and succeeded [build](https://github.com/canonical/charmcraftcache-hub/actions/runs/14792737495/job/41533293789)