### PR TITLE
fix: observe relation events in configuration sender component

### DIFF
--- a/charms/feast-integrator/src/components/store_configuration_sender_component.py
+++ b/charms/feast-integrator/src/components/store_configuration_sender_component.py
@@ -50,6 +50,11 @@ class StoreConfigurationSenderComponent(Component):
             charm=self.charm, relation_name=self.relation_name
         )
 
+        self._events_to_observe = [
+            self.charm.on[relation_name].relation_created,
+            self.charm.on[relation_name].relation_broken,
+        ]
+
     def create_store_configuration(self) -> FeastStoreConfiguration:
         """Create the FeastStoreConfiguration from the input context."""
         # Get databases context


### PR DESCRIPTION
Patches `StoreConfigurationSenderComponent` to observe relation events so users do not need to wait for update status