### PR TITLE
terraform: add missing `feast_configuration` output for `feast-integrator`

### DIFF
--- a/charms/feast-integrator/terraform/outputs.tf
+++ b/charms/feast-integrator/terraform/outputs.tf
@@ -2,6 +2,11 @@ output "app_name" {
   value = juju_application.feast_integrator.name
 }
 
+output "provides" {
+  value = {
+    feast_configuration = "feast-configuration",
+  }
+}
 
 output "requires" {
   value = {


### PR DESCRIPTION
the `feast-configuration` integration is missing from the `feast-integrator` terraform module