### PR TITLE
fix: application name and relation name in terraform modules

### DIFF
--- a/charms/feast-integrator/terraform/outputs.tf
+++ b/charms/feast-integrator/terraform/outputs.tf
@@ -11,7 +11,7 @@ output "provides" {
 output "requires" {
   value = {
     offline_store = "offline-store",
-    online_store  = "online_store",
+    online_store  = "online-store",
     registry      = "registry",
     secrets       = "secrets",
     pod_defaults  = "pod-defaults",

--- a/charms/feast-ui/terraform/variables.tf
+++ b/charms/feast-ui/terraform/variables.tf
@@ -1,7 +1,7 @@
 variable "app_name" {
   description = "Application name"
   type        = string
-  default     = "feast-integrator"
+  default     = "feast-ui"
 }
 
 variable "channel" {


### PR DESCRIPTION
* Fixes the name of `app_name` variable in `feast-ui` terraform module
* Fixes the name of `online_store` output in `feast-integrator` terraform module