### PR TITLE
(ci)chore: enable cache for charm builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -109,7 +109,6 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/build_charm.yaml@v31.0.1
     with:
       path-to-charm-directory: ${{ matrix.charm }}
-      cache: false #TODO remove when tester charm is added to charmcraftcache
     
   integration:
     name: Integration tests (microk8s)


### PR DESCRIPTION
Closes #21 
charms were added to cache in https://github.com/canonical/charmcraftcache-hub/issues/497 https://github.com/canonical/charmcraftcache-hub/issues/491 https://github.com/canonical/charmcraftcache-hub/issues/433