### PR TITLE
feat: add `FEAST_CONFIG_PATH` env to PodDefault

### DIFF
--- a/charms/feast-integrator/src/templates/feature_store_poddefault.yaml.j2
+++ b/charms/feast-integrator/src/templates/feature_store_poddefault.yaml.j2
@@ -3,14 +3,17 @@ kind: PodDefault
 metadata:
   name: {{ app_name }}-access-feast
 spec:
- desc: Allow access to Feast
- selector:
-   matchLabels:
-     access-feast: "true"
- volumeMounts:
-   - mountPath: /feast/feature-store.yaml
-     name: feature-store-yaml
- volumes:
-   - name: feature-store-yaml
-     secret:
-       secretName: {{ secret_name }}
+  desc: Allow access to Feast
+  selector:
+    matchLabels:
+      access-feast: "true"
+  env:
+    - name: FEAST_CONFIG_PATH
+      value: "/feast/feature_store.yaml"
+  volumeMounts:
+    - mountPath: /feast
+      name: feature-store-yaml
+  volumes:
+    - name: feature-store-yaml
+      secret:
+        secretName: {{ secret_name }}


### PR DESCRIPTION
Adds `FEAST_CONFIG_PATH` env var to access feast PodDefault, this is to enable users to run `feast` commands from the notebook terminal using the `-f` flag. For example:
```
feast -f "${FEAST_CONFIG_PATH}" apply	
```