### PR TITLE
fix: rename feast integrator env variable name

### DIFF
--- a/charms/feast-integrator/src/templates/feature_store_poddefault.yaml.j2
+++ b/charms/feast-integrator/src/templates/feature_store_poddefault.yaml.j2
@@ -8,7 +8,7 @@ spec:
     matchLabels:
       access-feast: "true"
   env:
-    - name: FEAST_CONFIG_PATH
+    - name: FEAST_FS_YAML_FILE_PATH
       value: "/feast/feature_store.yaml"
   volumeMounts:
     - mountPath: /feast


### PR DESCRIPTION
Use feast env variable for config file localisation. Based on this discussion: https://github.com/feast-dev/feast/issues/5416