### PR TITLE
feat: add docs index page

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -20,6 +20,7 @@ kubeflow
 lang
 LaTeX
 latexmk
+lifecycle
 materialize
 materializing
 MLOps

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -37,7 +37,7 @@ In this documentation
       :link: /how-to/index
       :link-type: doc
 
-      Step-by-step guides covering key operations and common tasks, from Notebook setup to CLI usage.
+      Step-by-step guides covering key operations and common tasks.
 
 .. grid:: 1 1 2 2
 
@@ -45,4 +45,4 @@ In this documentation
       :link: /explanation/index
       :link-type: doc
 
-      Discussion and clarification of core topics, including system architecture and integration details.
+      Discussion and clarification of core topics, including system architecture and integrations.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -17,7 +17,6 @@ This solution is ideal for teams using Charmed Kubeflow that need a robust, prod
    Tutorial </tutorial/index>
    How-to guides </how-to/index>
    Explanation </explanation/index>
-   Reference </reference/index>
 
 In this documentation
 ---------------------
@@ -38,8 +37,8 @@ In this documentation
 
 .. grid:: 1 1 2 2
 
-   .. grid-item-card:: Reference
-      :link: /reference/index
+   .. grid-item-card:: Explanation
+      :link: /explanation/index
       :link-type: doc
 
-      Technical details, charm interfaces, deployment specs, and configuration options.
+      Discussion and clarification of core topics, including system architecture and integration details.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -2,20 +2,24 @@
 Charmed Feast documentation
 ===========================
 
-Charmed Feast is a fully managed, Charmed Operator-based deployment of the Feast feature store, built for seamless integration with Charmed Kubeflow.
+Charmed Feast is a fully managed, `charm <https://documentation.ubuntu.com/juju/3.6/reference/charm/#charm>`_-based deployment of the `Feast <https://docs.feast.dev/>`_ feature store, 
+designed for seamless integration with `Charmed Kubeflow <https://charmed-kubeflow.io/>`_.
 
-It simplifies the deployment and life cycle management of Feast components using Juju, and connects directly to Kubeflow Notebooks, enabling feature registration and retrieval from a familiar ML environment.
+It simplifies the deployment and lifecycle management of Feast components using `Juju <https://juju.is/>`_, 
+and connects directly to Kubeflow Notebooks, enabling feature registration and retrieval from a familiar Machine Learning environment.
 
-Charmed Feast helps data scientists and MLOps engineers bridge the gap between data engineering and model deployment, by streamlining feature management across training and inference workflows.
+Charmed Feast helps data scientists and MLOps engineers bridge the gap between data engineering and model deployment, 
+by streamlining feature management across training and inference workflows.
 
-This solution is ideal for teams using Charmed Kubeflow that need a robust, production-ready feature store with PostgreSQL backing both online and offline retrieval use cases.
+This solution is ideal for teams using Charmed Kubeflow that need a robust, 
+production-ready feature store backed by PostgreSQL for both online and offline retrieval use cases.
 
 .. toctree::
    :hidden:
    :maxdepth: 2
 
    Tutorial </tutorial/index>
-   How-to guides </how-to/index>
+   How to </how-to/index>
    Explanation </explanation/index>
 
 In this documentation

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,4 +45,4 @@ In this documentation
       :link: /explanation/index
       :link-type: doc
 
-      Discussion and clarification of core topics, including system architecture and integrations.
+      Discussion and clarification of core topics.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,17 +1,23 @@
+
 Charmed Feast documentation
-============================
+===========================
 
-The documentation starter pack helps you to quickly set up, build, and publish documentation with Sphinx.
+Charmed Feast is a fully managed, Charmed Operator-based deployment of the Feast feature store, built for seamless integration with Charmed Kubeflow.
 
-It contains common styling and configuration through the `Canonical Sphinx`_ extension, supports both |RST| and Markdown, and includes automatic documentation checks.
+It simplifies the deployment and lifecycle management of Feast components using Juju, and connects directly to Kubeflow Notebooks, enabling feature registration and retrieval from a familiar ML environment.
+
+Charmed Feast helps data scientists and MLOps engineers bridge the gap between data engineering and model deployment, by streamlining feature management across training and inference workflows.
+
+This solution is ideal for teams using Charmed Kubeflow that need a robust, production-ready feature store with PostgreSQL backing both online and offline retrieval use cases.
 
 .. toctree::
    :hidden:
    :maxdepth: 2
 
    Tutorial </tutorial/index>
-   How to <how-to/index>
+   How-to guides </how-to/index>
    Explanation </explanation/index>
+   Reference </reference/index>
 
 In this documentation
 ---------------------
@@ -22,18 +28,18 @@ In this documentation
       :link: /tutorial/index
       :link-type: doc
 
-      Get started - a hands-on introduction to Charmed Feast for newcomers.
+      Get started - a hands-on introduction to Charmed Feast for new users.
 
    .. grid-item-card:: How-to guides
       :link: /how-to/index
       :link-type: doc
 
-      Step-by-step guides covering key operations and common tasks with Charmed Feast.
+      Step-by-step guides covering key operations and common tasks, from Notebook setup to CLI usage.
 
 .. grid:: 1 1 2 2
 
-   .. grid-item-card:: Explanation
-      :link: /explanation/index
+   .. grid-item-card:: Reference
+      :link: /reference/index
       :link-type: doc
 
-      Discussion and clarification of key topics.
+      Technical details, charm interfaces, deployment specs, and configuration options.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -4,7 +4,7 @@ Charmed Feast documentation
 
 Charmed Feast is a fully managed, Charmed Operator-based deployment of the Feast feature store, built for seamless integration with Charmed Kubeflow.
 
-It simplifies the deployment and lifecycle management of Feast components using Juju, and connects directly to Kubeflow Notebooks, enabling feature registration and retrieval from a familiar ML environment.
+It simplifies the deployment and life cycle management of Feast components using Juju, and connects directly to Kubeflow Notebooks, enabling feature registration and retrieval from a familiar ML environment.
 
 Charmed Feast helps data scientists and MLOps engineers bridge the gap between data engineering and model deployment, by streamlining feature management across training and inference workflows.
 


### PR DESCRIPTION
Closes: https://github.com/canonical/feast-operators/issues/38

Adds index page to the feast docs.

Preview:
![image](https://github.com/user-attachments/assets/95ef1a56-40a8-4b4d-9b6b-4811b83685e1)

