### PR TITLE
feat: update how-to guide on how to use scipy image

### DIFF
--- a/docs/how-to/use_charmed_feast.rst
+++ b/docs/how-to/use_charmed_feast.rst
@@ -10,18 +10,24 @@ Set up a Notebook for Charmed Feast
 2. Click ``Create a new notebook``.
 3. Fill in the required fields such as:
    - ``Notebook name``.
-   - ``Notebook image``. You can use the default ``scipy`` notebook image, which includes all necessary Feast dependencies.
+   - ``Notebook image``: You can use the default ``scipy`` notebook image, which includes all necessary Feast dependencies.
 4. Expand ``Advanced configuration``.
-5. Under configuration options, check ``Allow access to Feast``. **This step is required for all notebook images.**
+5. Under configuration options, check ``Allow access to Feast``. 
+
+.. warning::
+   This step is required for all notebook images.
+
 6. Click ``Create`` to launch the Notebook.
 
 .. note::
    Once the Notebook is running, click ``Connect`` to open the environment.
 
-Install Python dependencies (if needed)
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Install Python dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. warning::
+   If you are **not** using the ``scipy`` notebook image, you must manually install the required Python dependencies. 
 
-If you are **not** using the ``scipy`` notebook image, you must manually install the required package dependencies inside the Notebook:
+You can install the package dependencies within a Notebook as follows:
 
 .. code-block:: bash
 

--- a/docs/how-to/use_charmed_feast.rst
+++ b/docs/how-to/use_charmed_feast.rst
@@ -9,8 +9,10 @@ Set up a Notebook for Charmed Feast
 1. From the CKF dashboard, select ``Notebooks`` in the sidebar.
 2. Click ``Create a new notebook``.
 3. Fill in the required fields such as:
+
    - ``Notebook name``.
    - ``Notebook image``: You can use the default ``scipy`` notebook image, which includes all necessary Feast dependencies.
+   
 4. Expand ``Advanced configuration``.
 5. Under configuration options, check ``Allow access to Feast``. 
 

--- a/docs/how-to/use_charmed_feast.rst
+++ b/docs/how-to/use_charmed_feast.rst
@@ -1,4 +1,3 @@
-
 Use Charmed Feast from Charmed Kubeflow
 ========================================
 
@@ -11,18 +10,18 @@ Set up a Notebook for Charmed Feast
 2. Click ``Create a new notebook``.
 3. Fill in the required fields such as:
    - ``Notebook name``.
-   - ``Notebook image``.
+   - ``Notebook image``. You can use the default ``scipy`` notebook image, which includes all necessary Feast dependencies.
 4. Expand ``Advanced configuration``.
-5. Under configuration options, check ``Allow access to Feast``.
+5. Under configuration options, check ``Allow access to Feast``. **This step is required for all notebook images.**
 6. Click ``Create`` to launch the Notebook.
 
 .. note::
    Once the Notebook is running, click ``Connect`` to open the environment.
 
-Install Python dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Install Python dependencies (if needed)
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Inside the Notebook, install the required package dependencies:
+If you are **not** using the ``scipy`` notebook image, you must manually install the required package dependencies inside the Notebook:
 
 .. code-block:: bash
 


### PR DESCRIPTION
Closes: https://github.com/canonical/kubeflow-rocks/issues/208

Fix how to guide to mention usage of scipy image.