### PR TITLE
chore: pin charm dependencies in tests (track/0.49)

### DIFF
--- a/charms/feast-ui/tests/integration/charms_dependencies.py
+++ b/charms/feast-ui/tests/integration/charms_dependencies.py
@@ -12,17 +12,17 @@ REGISTRY = CharmSpec(
     charm="postgresql-k8s", channel="14/stable", trust=True, config={"profile": "testing"}
 )
 
-FEAST_INTEGRATOR = CharmSpec(charm="feast-integrator", channel="latest/edge", trust=True)
-METACONTROLLER = CharmSpec(charm="metacontroller-operator", channel="latest/edge", trust=True)
-RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="latest/edge", trust=True)
-ADMISSION_WEBHOOK = CharmSpec(charm="admission-webhook", channel="latest/edge", trust=True)
+FEAST_INTEGRATOR = CharmSpec(charm="feast-integrator", channel="0.49/edge", trust=True)
+METACONTROLLER = CharmSpec(charm="metacontroller-operator", channel="4.11/edge", trust=True)
+RESOURCE_DISPATCHER = CharmSpec(charm="resource-dispatcher", channel="2.0/edge", trust=True)
+ADMISSION_WEBHOOK = CharmSpec(charm="admission-webhook", channel="1.10/edge", trust=True)
 
 ISTIO_GATEWAY = CharmSpec(
-    charm="istio-gateway", channel="latest/edge", trust=True, config={"kind": "ingress"}
+    charm="istio-gateway", channel="1.28/edge", trust=True, config={"kind": "ingress"}
 )
 ISTIO_PILOT = CharmSpec(
     charm="istio-pilot",
-    channel="latest/edge",
+    channel="1.28/edge",
     trust=True,
     config={"default-gateway": "istio-gateway"},
 )


### PR DESCRIPTION
This PR pins the track of charm dependencies in tests.

### Same-repo (pinned to `track/0.49`)
- `feast-integrator`: `latest/edge` → `0.49/edge`

### External (resolved via Terraform Solutions track/1.11)
- `metacontroller-operator`: `latest/edge` → `4.11/edge`
- `resource-dispatcher`: `latest/edge` → `2.0/edge`
- `admission-webhook`: `latest/edge` → `1.10/edge`
- `istio-gateway`: `latest/edge` → `1.28/edge`
- `istio-pilot`: `latest/edge` → `1.28/edge`

### Unresolved (left unchanged)
- `postgresql-k8s` (`14/stable`) — postgresql-k8s not pinned in Solutions track/1.11

Refs: canonical/bundle-kubeflow#1379
