### PR TITLE
fix: handle multiple istio-ingress-route relations

### DIFF
--- a/charms/feast-ui/src/components/istio_relations_conflict_detector.py
+++ b/charms/feast-ui/src/components/istio_relations_conflict_detector.py
@@ -26,10 +26,12 @@ class IstioRelationsConflictDetectorComponent(Component):
 
     def get_status(self) -> StatusBase:  # noqa: D102
         """Check that ambient and sidecar relations are not present simultaneously."""
-        ambient_relation = self._charm.model.get_relation(self.ambient_relation_name)
-        sidecar_relation = self._charm.model.get_relation(self.sidecar_relation_name)
+        # NOTE: use `relations` (a list) rather than `get_relation`, which raises
+        # TooManyRelatedAppsError when more than one relation is present on an endpoint.
+        ambient_relations = self._charm.model.relations[self.ambient_relation_name]
+        sidecar_relations = self._charm.model.relations[self.sidecar_relation_name]
 
-        if ambient_relation and sidecar_relation:
+        if ambient_relations and sidecar_relations:
             logger.error(
                 f"Both '{self.ambient_relation_name}' and '{self.sidecar_relation_name}' "
                 "relations are present, remove one to unblock."

--- a/charms/feast-ui/tests/integration/test_charm_ambient.py
+++ b/charms/feast-ui/tests/integration/test_charm_ambient.py
@@ -23,6 +23,7 @@ from charms_dependencies import (
     REGISTRY,
     RESOURCE_DISPATCHER,
 )
+from lightkube.generic_resource import create_namespaced_resource
 from requests import get
 
 logger = logging.getLogger(__name__)
@@ -40,6 +41,20 @@ RETRY_FOR_THREE_MINUTES = tenacity.Retrying(
     reraise=True,
 )
 SERVICE_MESH_ENDPOINT = "service-mesh"
+
+# A second istio-ingress-k8s instance used to verify multiple-ingress support.
+SECOND_INGRESS_APP = "istio-ingress-k8s-alt"
+# Name of the HTTPRoute submitted by feast-ui (see AmbientIngressRequirerComponent).
+INGRESS_ROUTE_NAME = "http-route"
+# Gateway listener section for cleartext HTTP on port 80.
+HTTP_SECTION_NAME = "http-80"
+# Gateway API generic resources, resolved at runtime via lightkube.
+HTTPROUTE_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "HTTPRoute", "httproutes"
+)
+GATEWAY_RESOURCE = create_namespaced_resource(
+    "gateway.networking.k8s.io", "v1", "Gateway", "gateways"
+)
 
 
 def charm_path_from_root(charm_dir_name: str) -> Path:
@@ -187,6 +202,86 @@ def get_ingress_url(k8s_client, model_name: str) -> str:
 
 def test_feast_ui_ingress_accessible(lightkube_client: lightkube.Client, juju: jubilant.Juju):
     """Ensure that Feast UI is reachable through the Ingress."""
+    ingress_url = get_ingress_url(lightkube_client, juju.model)
+    feast_url = f"{ingress_url}{HTTP_PATH}"
+
+    for attempt in RETRY_FOR_THREE_MINUTES:
+        with attempt:
+            response = get(feast_url, timeout=10)
+            assert response.status_code == 200, f"Expected 200 OK, got {response.status_code}"
+            assert "Feast" in response.text or len(response.text) > 0, "Expected Feast UI content"
+
+
+def test_deploy_and_relate_second_ingress(juju: jubilant.Juju):
+    """Deploy a second istio-ingress-k8s and relate it to feast-ui.
+
+    feast-ui must accept more than one istio-ingress-route relation without erroring,
+    so it should remain active after the second ingress is related.
+    """
+    juju.deploy(
+        charm=ISTIO_INGRESS_K8S.charm,
+        app=SECOND_INGRESS_APP,
+        channel=ISTIO_INGRESS_K8S.channel,
+        trust=ISTIO_INGRESS_K8S.trust,
+    )
+    logger.info(f"Waiting for {SECOND_INGRESS_APP} to be active..")
+    juju.wait(lambda status: status.apps[SECOND_INGRESS_APP].is_active)
+
+    juju.integrate(
+        f"{SECOND_INGRESS_APP}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+        f"{CHARM_NAME}:{ISTIO_INGRESS_ROUTE_ENDPOINT}",
+    )
+    logger.info("Waiting for the UI to be active after relating the second ingress...")
+    juju.wait(
+        lambda status: status.apps[CHARM_NAME].is_active
+        and status.apps[SECOND_INGRESS_APP].is_active
+    )
+
+
+def test_httproute_attached_to_second_gateway(
+    lightkube_client: lightkube.Client, juju: jubilant.Juju
+):
+    """Verify the HTTPRoute for the second ingress is created and bound to its Gateway.
+
+    The istio-ingress-k8s charm names each route
+    ``{source_app}-{route_name}-httproute-{section}-{ingress_app}`` and binds it to a
+    Gateway named after the ingress application via ``parentRefs``. We assert that the
+    route created for the second ingress is attached to the *second* Gateway (not the
+    first) and routes the feast path to the feast-ui backend.
+    """
+    namespace = juju.model
+
+    expected_route_name = (
+        f"{CHARM_NAME}-{INGRESS_ROUTE_NAME}-httproute-{HTTP_SECTION_NAME}-{SECOND_INGRESS_APP}"
+    )
+
+    # The second Gateway should exist, named after the second ingress application.
+    lightkube_client.get(GATEWAY_RESOURCE, name=SECOND_INGRESS_APP, namespace=namespace)
+
+    # Retry to give the ingress charm time to reconcile the HTTPRoute resources.
+    httproute = None
+    for attempt in RETRY_FOR_THREE_MINUTES:
+        with attempt:
+            httproute = lightkube_client.get(
+                HTTPROUTE_RESOURCE, name=expected_route_name, namespace=namespace
+            )
+
+    parent_refs = httproute.spec["parentRefs"]
+    assert len(parent_refs) == 1
+    # The route must be attached to the SECOND gateway, not the first.
+    assert parent_refs[0]["name"] == SECOND_INGRESS_APP
+    assert parent_refs[0]["sectionName"] == HTTP_SECTION_NAME
+
+    # And it must route the feast path to the feast-ui backend.
+    rule = httproute.spec["rules"][0]
+    assert rule["matches"][0]["path"]["value"] == HTTP_PATH
+    assert rule["backendRefs"][0]["name"] == CHARM_NAME
+
+
+def test_feast_ui_ingress_accessible_after_second_ingress(
+    lightkube_client: lightkube.Client, juju: jubilant.Juju
+):
+    """Ensure Feast UI is still reachable through the ingress after adding a second ingress."""
     ingress_url = get_ingress_url(lightkube_client, juju.model)
     feast_url = f"{ingress_url}{HTTP_PATH}"
 

--- a/charms/feast-ui/tests/unit/test_charm.py
+++ b/charms/feast-ui/tests/unit/test_charm.py
@@ -5,6 +5,10 @@ import ops
 import pytest
 import yaml
 from charmed_kubeflow_chisme.exceptions import ErrorWithStatus
+from charms.istio_ingress_k8s.v0.istio_ingress_route import (
+    HTTPPathMatchType,
+    IstioIngressRouteConfig,
+)
 from ops.model import ActiveStatus, BlockedStatus, WaitingStatus
 from ops.testing import Container, Context, State
 
@@ -269,3 +273,86 @@ def test_ambient_mode_ingress_configurations(
 
             else:
                 ingress_submit_config.assert_not_called()
+
+
+@patch(
+    "components.store_configuration_reciver_component.StoreConfigurationReceiverComponent"
+    ".get_feature_store_yaml",
+    return_value=MOCKED_VALID_FEATURE_STORE_CONFIGURATIONS,
+)
+def test_multiple_istio_ingress_route_relations(mock_get_yaml, ctx):
+    """Test that multiple istio-ingress-route relations do not block the charm."""
+    state_in = State(
+        leader=True,
+        relations=[
+            ops.testing.Relation(
+                endpoint=RELATION_ENDPOINT_FOR_FEAST_CONFIGURATIONS,
+                interface=RELATION_INTERFACE_FOR_FEAST_CONFIGURATIONS,
+            ),
+            ops.testing.Relation(
+                endpoint=RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE,
+                interface=RELATION_INTERFACE_FOR_INGRESS_IN_AMBIENT_MODE,
+            ),
+            ops.testing.Relation(
+                endpoint=RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE,
+                interface=RELATION_INTERFACE_FOR_INGRESS_IN_AMBIENT_MODE,
+            ),
+        ],
+        containers=[Container(name="feast-ui", can_connect=True)],
+    )
+
+    # Reconciling the charm while more than one istio-ingress-route relation is
+    # present must not raise (e.g. TooManyRelatedAppsError) nor block the charm.
+    state_out = ctx.run(ctx.on.install(), state_in)
+
+    assert state_out.unit_status == ActiveStatus()
+
+
+@patch(
+    "components.store_configuration_reciver_component.StoreConfigurationReceiverComponent"
+    ".get_feature_store_yaml",
+    return_value=MOCKED_VALID_FEATURE_STORE_CONFIGURATIONS,
+)
+def test_each_istio_ingress_route_relation_receives_config(mock_get_yaml, ctx):
+    """Test that every istio-ingress-route relation databag receives a valid config."""
+    state_in = State(
+        leader=True,
+        relations=[
+            ops.testing.Relation(
+                endpoint=RELATION_ENDPOINT_FOR_FEAST_CONFIGURATIONS,
+                interface=RELATION_INTERFACE_FOR_FEAST_CONFIGURATIONS,
+            ),
+            ops.testing.Relation(
+                endpoint=RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE,
+                interface=RELATION_INTERFACE_FOR_INGRESS_IN_AMBIENT_MODE,
+            ),
+            ops.testing.Relation(
+                endpoint=RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE,
+                interface=RELATION_INTERFACE_FOR_INGRESS_IN_AMBIENT_MODE,
+            ),
+        ],
+        containers=[Container(name="feast-ui", can_connect=True)],
+    )
+
+    # The real requirer publishes the same config to every istio-ingress-route
+    # relation, so all related ingress providers are (re)configured at once.
+    state_out = ctx.run(ctx.on.install(), state_in)
+
+    ambient_relations_out = [
+        relation
+        for relation in state_out.relations
+        if relation.endpoint == RELATION_ENDPOINT_FOR_INGRESS_IN_AMBIENT_MODE
+    ]
+    assert len(ambient_relations_out) == 2
+
+    for relation in ambient_relations_out:
+        assert "config" in relation.local_app_data
+        config = IstioIngressRouteConfig.model_validate_json(relation.local_app_data["config"])
+
+        assert len(config.http_routes) == 1
+        http_route = config.http_routes[0]
+        assert http_route.matches[0].path.type == HTTPPathMatchType.PathPrefix
+        assert http_route.matches[0].path.value == EXPECTED_INGRESS_PATH_MATCHED_PREFIX
+        assert http_route.backends[0].service == METADATA["name"]
+        assert http_route.backends[0].port == EXPECTED_K8S_SERVICE_HTTP_PORT
+        assert http_route.listener.name == "http-80"

--- a/concierge.yaml
+++ b/concierge.yaml
@@ -13,7 +13,9 @@ providers:
       load-balancer:
         enabled: true
         l2-mode: true
-        cidrs: 10.64.140.43/32
+        # NOTE: at least two IPs required for integration tests: one for each of the
+        # two Istio ingress gateways
+        cidrs: 10.64.140.42/31
     bootstrap-constraints:
       root-disk: 2G
 


### PR DESCRIPTION
Part of https://github.com/canonical/bundle-kubeflow/issues/1446

Use `model.relations[...]` instead of `model.get_relation(...)` when checking ingress relations, so the charm no longer raises `TooManyRelatedAppsError` when more than one `istio-ingress-route` relation is present.

Add unit and integration tests covering multiple `istio-ingress-route` relations and verifying each relation receives a valid `HTTPRoute` config.

_Note: this PR was created with the help of AI_